### PR TITLE
Some typos and more inclusive language

### DIFF
--- a/manuscript/common-exclusion-pitfalls/venue.md
+++ b/manuscript/common-exclusion-pitfalls/venue.md
@@ -26,13 +26,13 @@ When choosing Venues, especially for Event locations, try and ensure buildings m
 ## Services and Amenities
   * Food
     * Label everything. Include ingredients.
-    * Prefer assemblable food (where each ingredient is labeled, and people pick which to combine). Example: baked potato and topings, tacos, salads
-  * Quite room
+    * Prefer assemblable food (where each ingredient is labeled, and people pick which to combine). Example: baked potato and toppings, tacos, salads
+  * Quiet room
   * Speaker room
   * Loud room (like for kids or game playing)
   * Childcare
-  * Private space with refrigeration for pumping breastmilk or dealing with mediation
-  * Translation
+  * Private space with refrigeration for pumping breastmilk or dealing with medication
+  * Translation and interpreting
     * Verbal
     * ASL
   * Live captioning


### PR DESCRIPTION
A few changes I made were, I think, just typos. It's possible the private space is for mediation or medication, but medication seemed more likely what was intended. 

I'm less certain about adding the word interpreting. My experience is that for oral language interpreting/translation (from English to Spanish, for example) the act of translating orally in real time is more accurately called interpreting. I did a bit of research and it seems like sign language might use translation to describe a real-time translation. I thought including both words interpreting and translation helps explain the goal whether people are familiar with the difference between the words or not.

Thank you to all the contributors for this packet. It is super helpful.